### PR TITLE
Refactor/static analysis

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/exceptions/ThreadInterruptedException.java
+++ b/src/main/java/org/asdfjkl/jfxchess/exceptions/ThreadInterruptedException.java
@@ -1,0 +1,9 @@
+package org.asdfjkl.jfxchess.exceptions;
+
+public class ThreadInterruptedException extends RuntimeException {
+
+    public ThreadInterruptedException( String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -43,7 +43,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.asdfjkl.jfxchess.util.ThreadInterruptedException;
+import org.asdfjkl.jfxchess.exceptions.ThreadInterruptedException;
 
 import static org.asdfjkl.jfxchess.gui.EngineOption.*;
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -41,11 +41,15 @@ import jfxtras.styles.jmetro.Style;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.asdfjkl.jfxchess.util.ThreadInterruptedException;
 
 import static org.asdfjkl.jfxchess.gui.EngineOption.*;
 
 public class DialogEngines {
 
+    private static final Logger LOGGER = Logger.getLogger(DialogEngines.class.getName());
     final FileChooser fileChooser = new FileChooser();
 
     Stage stage;
@@ -292,7 +296,9 @@ public class DialogEngines {
                     try {
                         Thread.sleep(40);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        LOGGER.log(Level.WARNING, "Interrupted!", e);
+                        Thread.currentThread().interrupt();
+                        throw new ThreadInterruptedException("Thread Interrupted", e);
                     }
                 }
 
@@ -311,8 +317,9 @@ public class DialogEngines {
                     try {
                         Thread.sleep(40);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
+                        LOGGER.log(Level.WARNING, "Interrupted!", e);
+                        Thread.currentThread().interrupt();
+                        throw new ThreadInterruptedException("Thread Interrupted", e);                    }
                 }
 
                 Engine engine = new Engine();
@@ -371,7 +378,9 @@ public class DialogEngines {
                         engineProcess.destroy();
                     }
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOGGER.log(Level.WARNING, "Interrupted!", e);
+                    Thread.currentThread().interrupt();
+                    throw new ThreadInterruptedException("Thread Interrupted", e);                   
                 }
 
                 // Add engine to the engineList and make the list item selected.

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -307,7 +307,6 @@ public class DialogEngines {
                     bro.write("uci\n");
                     bro.flush();
                 } catch (IOException e) {
-                    e.printStackTrace();
                     throw new RuntimeException("Failed to send UCI-commands to the engine process. "
                             + file.getAbsolutePath()
                             + e.getClass() + ": " + e.getMessage());
@@ -339,7 +338,6 @@ public class DialogEngines {
                                 engine.options.add(engineOption);
                             }
                         } catch (Exception e) {
-                            e.printStackTrace();
                             bre.close();
                             bri.close();
                             throw (new RuntimeException("Couldn't parse engine option: "
@@ -348,7 +346,6 @@ public class DialogEngines {
                         }
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
                     throw new RuntimeException("Failed to read commands from the engine process "
                             + file.getAbsolutePath()
                             + e.getClass() + ": " + e.getMessage());
@@ -365,7 +362,6 @@ public class DialogEngines {
                     bro.write("quit\n");
                     bro.flush();
                 } catch (IOException e) {
-                    e.printStackTrace();
                     throw new RuntimeException("Failed to send stop and quit to the engine process. "
                             + file.getAbsolutePath()
                             + e.getClass() + ": " + e.getMessage());

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineController.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineController.java
@@ -25,9 +25,12 @@ import javafx.beans.value.ObservableValue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.asdfjkl.jfxchess.util.ThreadInterruptedException;
 
 public class EngineController {
-
+    private static final Logger LOGGER = Logger.getLogger(EngineController.class.getName());
     final EngineThread engineThread;
     final BlockingQueue<String> cmdQueue = new LinkedBlockingQueue<String>();
     Engine currentEngine = null;
@@ -80,7 +83,9 @@ public class EngineController {
                 try {
                     cmdQueue.put("stop");
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOGGER.log(Level.WARNING, "Interrupted!", e);
+                    Thread.currentThread().interrupt();
+                    throw new ThreadInterruptedException("Thread Interrupted", e);
                 }
                 //inGoInfinite = false;
             }
@@ -89,7 +94,9 @@ public class EngineController {
         try {
             cmdQueue.put(cmd);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.WARNING, "Interrupted!", e);
+            Thread.currentThread().interrupt();
+            throw new ThreadInterruptedException("Thread Interrupted", e);
         }
     }
 
@@ -100,7 +107,9 @@ public class EngineController {
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                LOGGER.log(Level.WARNING, "Interrupted!", e);
+                Thread.currentThread().interrupt();
+                throw new ThreadInterruptedException("Thread Interrupted", e);
             }
         } while (engineThread.engineIsOn());
     }
@@ -117,7 +126,9 @@ public class EngineController {
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                LOGGER.log(Level.WARNING, "Interrupted!", e);
+                Thread.currentThread().interrupt();
+                throw new ThreadInterruptedException("Thread Interrupted", e);
             }
         } while (!engineThread.engineIsOn());
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineController.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineController.java
@@ -27,7 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.asdfjkl.jfxchess.util.ThreadInterruptedException;
+import org.asdfjkl.jfxchess.exceptions.ThreadInterruptedException;
 
 public class EngineController {
     private static final Logger LOGGER = Logger.getLogger(EngineController.class.getName());

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.asdfjkl.jfxchess.util.ThreadInterruptedException;
+import org.asdfjkl.jfxchess.exceptions.ThreadInterruptedException;
 
 public class EngineThread extends Thread {
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineThread.java
@@ -26,9 +26,13 @@ import java.util.concurrent.BlockingQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.asdfjkl.jfxchess.util.ThreadInterruptedException;
 
 public class EngineThread extends Thread {
 
+    private static final Logger LOGGER = Logger.getLogger(EngineThread.class.getName());
     static final Pattern REG_MOVES = Pattern.compile("\\s[a-z]\\d[a-z]\\d([a-z]{0,1})");
     static final Pattern REG_BESTMOVE = Pattern.compile("bestmove\\s([a-z]\\d[a-z]\\d[a-z]{0,1})");
     static final Pattern REG_STRENGTH = Pattern.compile("UCI_Elo value \\d+");
@@ -105,7 +109,9 @@ public class EngineThread extends Thread {
 	    engineInput.write(cmd + "\n");
 	    engineInput.flush();
 	} catch (IOException | InterruptedException e) {
-	    e.printStackTrace(System.out);
+        LOGGER.log(Level.WARNING, "Interrupted!", e);
+        Thread.currentThread().interrupt();
+        throw new ThreadInterruptedException("Thread Interrupted", e);
 	}
     }
 
@@ -118,7 +124,9 @@ public class EngineThread extends Thread {
         	try {
                 Thread.sleep(1);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                LOGGER.log(Level.WARNING, "Interrupted!", e);
+                Thread.currentThread().interrupt();
+                throw new ThreadInterruptedException("Thread Interrupted", e);
             }
 
             if (this.isInterrupted()) {
@@ -135,7 +143,9 @@ public class EngineThread extends Thread {
                             engineProcess.destroy();
                         }
                     } catch(IOException | InterruptedException e) {
-                    e.printStackTrace(System.out);
+                        LOGGER.log(Level.WARNING, "Interrupted!", e);
+                        Thread.currentThread().interrupt();
+                        throw new ThreadInterruptedException("Thread Interrupted", e);
                     }
                 }
                 // Stop this thread.
@@ -222,7 +232,9 @@ public class EngineThread extends Thread {
                             this.engineInfo.strength = -1;
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace(System.out);
+                        LOGGER.log(Level.WARNING, "Interrupted!", e);
+                        Thread.currentThread().interrupt();
+                        throw new ThreadInterruptedException("Thread Interrupted", e);
                     }
                 }
                 continue;
@@ -294,7 +306,9 @@ public class EngineThread extends Thread {
                             engineProcess.destroy();
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace(System.out);
+                        LOGGER.log(Level.WARNING, "Interrupted!", e);
+                        Thread.currentThread().interrupt();
+                        throw new ThreadInterruptedException("Thread Interrupted", e);
                     }
                     continue;
                 }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/LoadingDialog.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/LoadingDialog.java
@@ -1,0 +1,82 @@
+package org.asdfjkl.jfxchess.gui;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import jfxtras.styles.jmetro.JMetro;
+
+public class LoadingDialog {
+
+    private Stage stage;
+    private JMetro jMetro;
+    private Scene scene;
+    private Label lblScanPgn;
+    private ProgressBar progressBar;
+    private VBox vbox;
+
+    public void showLoadingDialog(String message) {
+        stage = createStage();
+        scene = createScene(message);
+        
+        jMetro = new JMetro();
+        jMetro.setScene(scene);
+        
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    private Stage createStage() {
+        Stage newStage = new Stage();
+        newStage.initModality(Modality.APPLICATION_MODAL);
+        newStage.initStyle(StageStyle.UNDECORATED);
+        return newStage;
+    }
+
+    private Scene createScene(String message) {
+        lblScanPgn = new Label(message);
+        progressBar = new ProgressBar();
+
+        vbox = new VBox(10, lblScanPgn, progressBar);
+        vbox.setAlignment(Pos.CENTER);
+        vbox.setPadding(new Insets(10));
+
+        return new Scene(vbox, 400, 200);
+    }
+
+    public void close() {
+        if (stage != null) {
+            stage.close();
+        }
+    }
+
+    public Stage getStage() {
+        return stage;
+    }
+
+    public JMetro getjMetro() {
+        return jMetro;
+    }
+
+    public Scene getScene() {
+        return scene;
+    }
+
+    public Label getLblScanPgn() {
+        return lblScanPgn;
+    }
+
+    public ProgressBar getProgressBar() {
+        return progressBar;
+    }
+
+    public VBox getVbox() {
+        return vbox;
+    }
+
+}

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Main.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Main.java
@@ -21,44 +21,57 @@ package org.asdfjkl.jfxchess.gui;
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileLock;
+import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.io.IOException;
 
 public class Main {
+    private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
     public static void main(String[] args) {
-        // System.setProperty("prism.lcdtext", "false");
-        // System.setProperty("prism.subpixeltext", "false");
-
-        String dir = System.getProperty("user.home");
-        File fDir = new File(dir);
-        File file = new File(fDir, "x43890423_jry.lock");
-        if(!lockInstance(file.getAbsolutePath())) {
-            return;
+        try {
+            String dir = System.getProperty("user.home");
+            File fDir = new File(dir);
+            File file = new File(fDir, "x43890423_jry.lock");
+            if (!lockInstance(file.getAbsolutePath())) {
+                LOGGER.log(Level.SEVERE, "Another instance of the application is already running.");
+                System.exit(1);
+            }
+            App.main(args);
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "An IO error occurred during startup", e);
+            System.exit(1);
         }
-        App.main(args);
     }
 
-    private static boolean lockInstance(final String lockFile) {
-        try {
-            final File file = new File(lockFile);
-            final RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
-            final FileLock fileLock = randomAccessFile.getChannel().tryLock();
-            if (fileLock != null) {
-                Runtime.getRuntime().addShutdownHook(new Thread() {
-                    public void run() {
-                        try {
-                            fileLock.release();
-                            randomAccessFile.close();
-                            file.delete();
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-                });
-                return true;
+    private static boolean lockInstance(final String lockFile) throws IOException {
+        final File file = new File(lockFile);
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
+            FileChannel fileChannel = randomAccessFile.getChannel()) {
+                
+            Optional<FileLock> fileLock = Optional.ofNullable(fileChannel.tryLock());
+
+            if (fileLock.isEmpty()) {
+                return false;
             }
-        } catch (Exception e) {
-            e.printStackTrace();
+
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    fileLock.get().release();
+                    Files.deleteIfExists(file.toPath()); 
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, "Error releasing file lock!", e);
+                }
+            }));
+            return true;
+        } catch (OverlappingFileLockException e) {
+            LOGGER.log(Level.SEVERE, "File is already locked by another process.", e);
+            return false;
         }
-        return false;
     }
 
 }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/PgnDatabase.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/PgnDatabase.java
@@ -115,7 +115,7 @@ public class PgnDatabase {
 
     public void saveDatabaseAs(String filename) {
 
-        String tmpFilenameWoDir = Util.getRandomFilename();
+        String tmpFilenameWoDir = new Util().getRandomFilename();
 
         File file = new File(filename);
         File path = file.getParentFile();
@@ -406,7 +406,7 @@ public class PgnDatabase {
 
     public void deleteGame(int index) {
 
-        String tmpFilenameWoDir = Util.getRandomFilename();
+        String tmpFilenameWoDir = new Util().getRandomFilename();
 
         File file = new File(filename);
         File path = file.getParentFile();

--- a/src/main/java/org/asdfjkl/jfxchess/gui/PgnDatabase.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/PgnDatabase.java
@@ -21,17 +21,10 @@ package org.asdfjkl.jfxchess.gui;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
-import javafx.scene.Scene;
-import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
-import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
-import javafx.stage.StageStyle;
-import jfxtras.styles.jmetro.JMetro;
 import org.asdfjkl.jfxchess.lib.*;
 
 import java.io.BufferedWriter;
@@ -46,7 +39,6 @@ public class PgnDatabase {
     private ObservableList<PgnDatabaseEntry> searchResults;
     final PgnReader reader;
     String filename;
-    static Stage stage;
 
     DialogDatabase dialogDatabase = null;
 
@@ -130,27 +122,9 @@ public class PgnDatabase {
 
         final ObservableList<PgnDatabaseEntry> entries = this.entries;
 
-        stage = new Stage();
-        stage.initModality(Modality.APPLICATION_MODAL);
-        stage.initStyle(StageStyle.UNDECORATED);
 
-        Label lblScanPgn = new Label("Saving PGN...");
-        ProgressBar progressBar = new ProgressBar();
-
-        VBox vbox = new VBox();
-        vbox.setAlignment(Pos.CENTER);
-        vbox.getChildren().addAll(lblScanPgn, progressBar);
-
-        vbox.setSpacing(10);
-        vbox.setPadding( new Insets(10));
-
-        Scene scene = new Scene(vbox, 400, 200);
-
-        JMetro jMetro = new JMetro();
-        jMetro.setScene(scene);
-
-        stage.setScene(scene);
-        stage.show();
+        LoadingDialog loadingDialog = new LoadingDialog();
+        loadingDialog.showLoadingDialog("Saving PGN...");
 
         Task<Void> task = new Task<>() {
             @Override protected Void call() throws Exception {
@@ -263,13 +237,13 @@ public class PgnDatabase {
             }
         };
 
-
+        ProgressBar progressBar = loadingDialog.getProgressBar();
         progressBar.progressProperty().bind(task.progressProperty());
 
         task.setOnSucceeded(e -> {
             unregisterRunningTask(task);
             task.getValue();
-            stage.close();
+            loadingDialog.close();
             if(this.dialogDatabase != null) {
                 dialogDatabase.updateTable();
             }
@@ -421,27 +395,8 @@ public class PgnDatabase {
 
         final ObservableList<PgnDatabaseEntry> entries = this.entries;
 
-        stage = new Stage();
-        stage.initModality(Modality.APPLICATION_MODAL);
-        stage.initStyle(StageStyle.UNDECORATED);
-
-        Label lblScanPgn = new Label("Deleting Game...");
-        ProgressBar progressBar = new ProgressBar();
-
-        VBox vbox = new VBox();
-        vbox.setAlignment(Pos.CENTER);
-        vbox.getChildren().addAll(lblScanPgn, progressBar);
-
-        vbox.setSpacing(10);
-        vbox.setPadding( new Insets(10));
-
-        Scene scene = new Scene(vbox, 400, 200);
-
-        JMetro jMetro = new JMetro();
-        jMetro.setScene(scene);
-
-        stage.setScene(scene);
-        stage.show();
+        LoadingDialog loadingDialog = new LoadingDialog();
+        loadingDialog.showLoadingDialog("Deleting Game...");
 
         Task<Void> task = new Task<>() {
             @Override protected Void call() throws Exception {
@@ -536,13 +491,13 @@ public class PgnDatabase {
             }
         };
 
-
+        ProgressBar progressBar = loadingDialog.getProgressBar();
         progressBar.progressProperty().bind(task.progressProperty());
 
         task.setOnSucceeded(e -> {
             unregisterRunningTask(task);
             task.getValue();
-            stage.close();
+            loadingDialog.close();
             if(this.dialogDatabase != null) {
                 dialogDatabase.updateTable();
             }
@@ -559,27 +514,8 @@ public class PgnDatabase {
 
     public void open() {
 
-        stage = new Stage();
-        stage.initModality(Modality.APPLICATION_MODAL);
-        stage.initStyle(StageStyle.UNDECORATED);
-
-        Label lblScanPgn = new Label("Scanning PGN...");
-        ProgressBar progressBar = new ProgressBar();
-
-        VBox vbox = new VBox();
-        vbox.setAlignment(Pos.CENTER);
-        vbox.getChildren().addAll(lblScanPgn, progressBar);
-
-        vbox.setSpacing(10);
-        vbox.setPadding( new Insets(10));
-
-        Scene scene = new Scene(vbox, 400, 200);
-
-        JMetro jMetro = new JMetro();
-        jMetro.setScene(scene);
-
-        stage.setScene(scene);
-        stage.show();
+        LoadingDialog loadingDialog = new LoadingDialog();
+        loadingDialog.showLoadingDialog("Scanning PGN...");
 
         final String tmpFilename = this.filename;
 
@@ -708,13 +644,13 @@ public class PgnDatabase {
             }
         };
 
-
+        ProgressBar progressBar = loadingDialog.getProgressBar();
         progressBar.progressProperty().bind(task.progressProperty());
 
         task.setOnSucceeded(e -> {
             unregisterRunningTask(task);
             entries = task.getValue();
-            stage.close();
+            loadingDialog.close();
             if(this.dialogDatabase != null) {
                 dialogDatabase.updateTable();
                 dialogDatabase.table.scrollTo(0);
@@ -730,28 +666,8 @@ public class PgnDatabase {
 
     public void search(SearchPattern pattern) {
 
-        stage = new Stage();
-        stage.initModality(Modality.APPLICATION_MODAL);
-        stage.initStyle(StageStyle.UNDECORATED);
-
-        Label lblScanPgn = new Label("Searching...");
-        ProgressBar progressBar = new ProgressBar();
-
-        VBox vbox = new VBox();
-        vbox.setAlignment(Pos.CENTER);
-        vbox.getChildren().addAll(lblScanPgn, progressBar);
-
-        vbox.setSpacing(10);
-        vbox.setPadding( new Insets(10));
-
-        Scene scene = new Scene(vbox, 400, 200);
-
-        JMetro jMetro = new JMetro();
-        jMetro.setScene(scene);
-
-        stage.setScene(scene);
-        stage.show();
-
+        LoadingDialog loadingDialog = new LoadingDialog();
+        loadingDialog.showLoadingDialog("Searching...");
 
         Task<ObservableList<PgnDatabaseEntry>> task = new Task<>() {
             @Override protected ObservableList<PgnDatabaseEntry> call() throws Exception {
@@ -809,12 +725,13 @@ public class PgnDatabase {
             }
         };
 
+        ProgressBar progressBar = loadingDialog.getProgressBar();
         progressBar.progressProperty().bind(task.progressProperty());
 
         task.setOnSucceeded(e -> {
             unregisterRunningTask(task);
             searchResults = task.getValue();
-            stage.close();
+            loadingDialog.close();
             if(this.dialogDatabase != null) {
                 dialogDatabase.updateTableWithSearchResults();
             }
@@ -825,8 +742,5 @@ public class PgnDatabase {
         thread.setDaemon(false);
         thread.start();
     }
-
-
-
 
 }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/PgnDatabase.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/PgnDatabase.java
@@ -109,7 +109,7 @@ public class PgnDatabase {
 
     public void saveDatabaseAs(String filename) {
 
-        String tmpFilenameWoDir = new Util().getRandomFilename();
+        String tmpFilenameWoDir = Util.getRandomFilename();
 
         File file = new File(filename);
         File path = file.getParentFile();

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
@@ -1,7 +1,8 @@
 package org.asdfjkl.jfxchess.gui;
 
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
 import java.util.Date;
-import java.util.Random;
 
 public class Util {
 
@@ -9,7 +10,10 @@ public class Util {
 
         Date date = new Date();
         long timeInMilliseconds = date.getTime();
-        Random random = new Random(timeInMilliseconds);
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(timeInMilliseconds);
+        byte[] seed = buffer.array();
+        SecureRandom random = new SecureRandom(seed);
 
         String filename = "";
         for(int i=0;i<8;i++) {

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
@@ -1,23 +1,16 @@
 package org.asdfjkl.jfxchess.gui;
 
-import java.nio.ByteBuffer;
 import java.security.SecureRandom;
-import java.util.Date;
 
 public class Util {
 
-    public String getRandomFilename() {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-        Date date = new Date();
-        long timeInMilliseconds = date.getTime();
-        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-        buffer.putLong(timeInMilliseconds);
-        byte[] seed = buffer.array();
-        SecureRandom random = new SecureRandom(seed);
+    public static String getRandomFilename() {
 
         StringBuilder filename = new StringBuilder();
         for(int i=0;i<8;i++) {
-            char c = (char) (random.nextInt(26) + 97);
+            char c = (char) (SECURE_RANDOM.nextInt(26) + 97);
             filename.append(c);
         }
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
@@ -6,7 +6,7 @@ import java.util.Date;
 
 public class Util {
 
-    public static String getRandomFilename() {
+    public String getRandomFilename() {
 
         Date date = new Date();
         long timeInMilliseconds = date.getTime();

--- a/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/Util.java
@@ -15,13 +15,13 @@ public class Util {
         byte[] seed = buffer.array();
         SecureRandom random = new SecureRandom(seed);
 
-        String filename = "";
+        StringBuilder filename = new StringBuilder();
         for(int i=0;i<8;i++) {
             char c = (char) (random.nextInt(26) + 97);
-            filename += c;
+            filename.append(c);
         }
 
-        return filename + ".tmp";
+        return filename.append(".tmp").toString();
     }
 
 }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/Arrow.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/Arrow.java
@@ -9,17 +9,19 @@ public class Arrow {
 
     @Override
     public boolean equals(Object o) {
-
+        boolean result = false;
         if (o instanceof Arrow) {
             Arrow other = (Arrow) o;
             if (other.xFrom == xFrom && other.yFrom == yFrom
                     && other.xTo == xTo && other.yTo == yTo) {
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+                result = true;
+            } 
+        } 
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/Board.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/Board.java
@@ -266,7 +266,7 @@ public class Board {
             throw new IllegalArgumentException("fen: turn part is invalid in "+fen);
         }
         // check that castles part in correctly encoded using regex
-        boolean castlesMatch = fenParts[2].matches("^-|[KQABCDEFGH]{0,2}[kqabcdefgh]{0,2}$");
+        boolean castlesMatch = fenParts[2].matches("^(?:-|(?:[KQABCDEFGH]{0,2}[kqabcdefgh]{0,2}))$");
         if(!castlesMatch) {
             throw new IllegalArgumentException("fen: castles encoding is invalid in "+fen);
         }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/ColoredField.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/ColoredField.java
@@ -7,17 +7,19 @@ public class ColoredField {
 
     @Override
     public boolean equals(Object o) {
-
+        boolean result = false;
         if (o instanceof ColoredField) {
             ColoredField other = (ColoredField) o;
             if(other.x == x && other.y == y) {
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+                result = true;
+            } 
+        } 
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 
 }

--- a/src/main/java/org/asdfjkl/jfxchess/lib/OptimizedRandomAccessFile.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/OptimizedRandomAccessFile.java
@@ -317,7 +317,7 @@ public class OptimizedRandomAccessFile {
                     nextChar++;
                 }
             }
-            long d = nChars - nextChar;
+            long d = (long) nChars - nextChar;
             if (r <= d) {
                 nextChar += r;
                 r = 0;

--- a/src/main/java/org/asdfjkl/jfxchess/lib/PgnReader.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/PgnReader.java
@@ -62,6 +62,8 @@ public class PgnReader {
                     if (game_pos == -1) {
                         game_pos = last_pos;
                         current = new PgnDatabaseEntry();
+                    } else if (current == null) {  
+                        current = new PgnDatabaseEntry();
                     }
                     last_pos = raf.getFilePointer();
 
@@ -99,7 +101,7 @@ public class PgnReader {
                     inComment = currentLine.lastIndexOf("{") > currentLine.lastIndexOf("}");
                 }
 
-                if (game_pos != -1) {
+                if (game_pos != -1 && current != null) {
                     current.setOffset(game_pos);
                     entries.add(current);
                     game_pos = -1;

--- a/src/main/java/org/asdfjkl/jfxchess/lib/PolyglotExt.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/PolyglotExt.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.security.SecureRandom;
 
 public class PolyglotExt {
 
@@ -238,7 +239,7 @@ public class PolyglotExt {
             for(PolyglotExtEntry entry : entries) {
                 overallCount += entry.count;
             }
-            int idx = (int) (Math.random() * overallCount);
+            int idx = (new SecureRandom().nextInt() * overallCount);
             int tempCount = 0;
             for(PolyglotExtEntry entry : entries) {
                 tempCount += entry.count;

--- a/src/main/java/org/asdfjkl/jfxchess/lib/PolyglotExt.java
+++ b/src/main/java/org/asdfjkl/jfxchess/lib/PolyglotExt.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.security.SecureRandom;
 
 public class PolyglotExt {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     byte[] book;
     public boolean readFile = false;
@@ -239,7 +240,7 @@ public class PolyglotExt {
             for(PolyglotExtEntry entry : entries) {
                 overallCount += entry.count;
             }
-            int idx = (new SecureRandom().nextInt() * overallCount);
+            int idx = (SECURE_RANDOM.nextInt() * overallCount);
             int tempCount = 0;
             for(PolyglotExtEntry entry : entries) {
                 tempCount += entry.count;


### PR DESCRIPTION
# **Static Analysis Refactoring**

1. In [PolyglotExt.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/compare/master...Engenharia-de-Software-2024-1:jfxchess:refactor/static-analysis?diff=unified&w=#diff-3a71064156cf3d67d0dae397d20c9c15298a360163dd754df47f1a2baf055ea9) and in [Util.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/compare/master...Engenharia-de-Software-2024-1:jfxchess:refactor/static-analysis?diff=unified&w=#diff-6e8a4ad60cde057331304181fd9c611dc40d966ade1a9471cc3aa3301cba61b2) the project were using a pseudo-random number generator, so I replaced this use to a cryptographically secure random number generator in Java to enhance security. Why does it need to be changed? Because standard Random Generators, like `java.util.Random`, are deterministic and can be predicted if the seed is known. By switching to `java.security.SecureRandom`, I ensured that the random values are less predictable. The outdated use of a pseudo-random number generator were being classified as [**security-sensitive** on SonarQube](https://rules.sonarsource.com/java/type/Security%20Hotspot/RSPEC-2245/).

2. The regular expression in [Board.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/compare/master...Engenharia-de-Software-2024-1:jfxchess:refactor/static-analysis?diff=unified&w=#diff-3f2a7b74aabe8bee12bd0e81edff5e5cabe61105c4038e6614cd315bf2fac27a) was initially flagged as a bug by [SonarQube rule S5850](https://rules.sonarsource.com/java/tag/regex/RSPEC-5850/). To address this, I applied the compliant solution suggested by SonarQube. However, this update triggered a [Code Smell warning (S6395)](https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-6395/?search=optional).  So, I decided to proceed with the fix for the original bug (S5850) and mark the Code Smell (S6395) as a false positive. The main reason for my decision is that accepting S6395's compliant solution would introduce unintended pattern matches. This approach is supported by an ongoing discussion in the [SonarQube community](https://community.sonarsource.com/t/non-cap-group-w-o-quantifier-specified-by-s5850-and-proscribed-by-s6395/110258/5).

3. The following changes were made in accordance with [SonarQube rule S2142](https://rules.sonarsource.com/java/tag/multi-threading/RSPEC-2142/), which states that `InterruptedException` and `ThreadDeath` should not be ignored. So, I addressed the compliant solution by adding Logs, properly handling the exception by interrupting the Thread and guaranteeing that the Exception will correctly propagates throughout the project. Furthermore, the creation of [`ThreadInterruptedException.java`](https://github.com/Engenharia-de-Software-2024-1/jfxchess/compare/master...Engenharia-de-Software-2024-1:jfxchess:refactor/static-analysis?diff=unified&w=#diff-5521d9edf924cc86d5319524f53c71634dae809687396ace18b95806bf19d238) was done in accordance with [SonarQube rule S112](https://next.sonarqube.com/sonarqube/coding_rules?open=java%3AS112&rule_key=java%3AS112), which states that generic exceptions should nerver be thrown. These refactorings were applied to the following snippets:
  - [DialogEngines](https://github.com/Engenharia-de-Software-2024-1/jfxchess/compare/master...Engenharia-de-Software-2024-1:jfxchess:refactor/static-analysis?diff=unified&w=#diff-736dd47c11ebc0be4b1af18bd5b6c0707add2e7b6edd4deee02076ed12211e75)
  - [EngineController.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-987a2eff548312a737c7d15400ed8cd5f422699c824a34d0590c5c6bebf14bff)
  - [EngineThread.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-335e92ac7f3788cb0abe941542d6bc47194ab26fdcba1e3d0fd762aa374a4cd4)
  - [Main.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-6575e1704006b129176e5d21431e1bcc2ae537bd4222b64cd34395397e205f06)

4. In [PgnDatabase.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-975e1344f44f02f9fa5ba40679b66b587dac2dc7e8e59dc25d648f994bb43679) the SonarQube identified many duplicated lines. So, the main goal were to reduce these duplicated line by creating a new class, [LoadingDialog.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-f67e17191bdaed779963293490f631287a93933b4536dcd684cee80a822709cf), that would incorporate these same tasks in a single sub task, reducing the [brain method (RSPEC-6541)](https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-6541/?search=cognitive), lowering the [cognitive complexity (RSPEC-3776))](https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-3776/?search=cognitive) and removing the identified duplicated lines. It's important to note that not all duplicated lines were removed, as the cost and quantity made it impractical.

5. As a final approach, some minor issues could lead the whole project to a complete failure, in [PgnReader.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-91a3402b45305da7f4d88185e2d85c2e41744aa8ce74fd524c9283d478cf863a) a `NullPointerException` could be thrown as identified by [SonarQube rule S2259](https://next.sonarqube.com/sonarqube/coding_rules?open=java%3AS2259&rule_key=java%3AS2259). Therefore, I addressed to the compliant solution by properly handling the case where current could be null.

## Minor fixes: 
- [ColoredField.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-6cd83de0ce85c978451fb05141ce7f8fcedf3837e36625ad5be771982f375c36) and [Arrow.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-5ac289ca4ff2176d9ac836100d9dccd807e2006dc68a06805b4fa22f1e9bf67e): Using a single `if` statement and overriding `hashCode` since `equals` has already been overridden. [S1126](https://sonarqube.ow2.org/coding_rules?open=java%3AS1126&rule_key=java%3AS1126) and [RSPEC-1206](https://rules.sonarsource.com/java/RSPEC-1206/?search=equals)
- [Util.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-6e8a4ad60cde057331304181fd9c611dc40d966ade1a9471cc3aa3301cba61b2): Strings should not be concatenated using '+' in a loop. [S1643](https://next.sonarqube.com/sonarqube/coding_rules?open=java:S1643&rule_key=java:S1643)
- [OptimizedRandomAccessFile.java](https://github.com/Engenharia-de-Software-2024-1/jfxchess/pull/1/files#diff-7112f0aca3cb60b77676aacbe0631f881c1580aa4d8f121cfdeb2d84472bc2e2): Casting one of the operands of this subtraction operation to a "long". [RSPEC-2184](https://rules.sonarsource.com/java/tag/overflow/RSPEC-2184/)
